### PR TITLE
Add header connections order

### DIFF
--- a/docs/user_guide/structure_of_the_yaml_input_file.md
+++ b/docs/user_guide/structure_of_the_yaml_input_file.md
@@ -56,6 +56,7 @@ cv:
   email: youremail@yourdomain.com
   phone: +905419999999 # (1)!
   website: https://example.com/
+  connections_order: [location, email, phone, website, social_networks]
   social_networks:
     - network: LinkedIn # (2)!
       username: yourusername
@@ -66,6 +67,9 @@ cv:
 
 1.  If you want to change the phone number formatting in the output, see the `locale` field's `phone_number_format` key.
 2.  The available social networks are: {{available_social_networks}}.
+3.  Use `connections_order` to customize the order of the items shown in
+    the header. Valid values are `location`, `email`, `phone`, `website`,
+    and `social_networks`.
 
 None of the values above are required. You can omit any or all of them, and RenderCV will adapt to your input. These generic fields are used in the header of the CV.
 
@@ -78,6 +82,7 @@ cv:
   email: youremail@yourdomain.com
   phone: +905419999999
   website: https://yourwebsite.com/
+  connections_order: [location, email, phone, website, social_networks]
   social_networks:
     - network: LinkedIn
       username: yourusername

--- a/schema.json
+++ b/schema.json
@@ -242,6 +242,27 @@
             }
           ]
         },
+        "connections_order": {
+          "default": null,
+          "title": "Order of Connections",
+          "description": "Preferred order of header items.",
+          "oneOf": [
+            {
+              "items": {
+                "enum": [
+                  "location",
+                  "email",
+                  "phone",
+                  "website",
+                  "social_networks"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {"type": "null"}
+          ]
+        },
         "social_networks": {
           "default": null,
           "title": "Social Networks",


### PR DESCRIPTION
## Summary
- allow customizing the order of header contact info
- document `connections_order` option in user guide
- update schema

## Testing
- `pre-commit run --files rendercv/data/models/curriculum_vitae.py schema.json docs/user_guide/structure_of_the_yaml_input_file.md`
- `pytest -q` *(fails: packages.typst.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c3e890b18832694586590a34562b8