### PR TITLE
Add optional résumé entry date sorting

### DIFF
--- a/rendercv/data/__init__.py
+++ b/rendercv/data/__init__.py
@@ -44,7 +44,12 @@ from .models import (
     make_a_url_clean,
     make_keywords_bold_in_a_string,
     rendercv_data_model_fields,
+    computers,
 )
+
+# Re-export sort_entries for public API convenience
+sort_entries = computers.sort_entries  # type: ignore[attr-defined]
+
 from .reader import (
     get_error_message_and_location_and_value_from_a_custom_error,
     parse_validation_errors,
@@ -88,5 +93,6 @@ __all__ = [
     "read_a_yaml_file",
     "read_input_file",
     "rendercv_data_model_fields",
+    "sort_entries",
     "validate_input_dictionary_and_return_the_data_model",
 ]

--- a/rendercv/data/models/rendercv_settings.py
+++ b/rendercv/data/models/rendercv_settings.py
@@ -5,7 +5,7 @@ The `rendercv.models.rendercv_settings` module contains the data model of the
 
 import datetime
 import pathlib
-from typing import Optional
+from typing import Optional, Literal
 
 import pydantic
 
@@ -220,6 +220,23 @@ class RenderCVSettings(RenderCVBaseModelWithoutExtraKeys):
         description=(
             "The keywords that will be bold in the output. The default value is an"
             " empty list."
+        ),
+    )
+
+    # Add a field to control the sorting order of entries in each section.
+    # Possible values:
+    #   * "reverse"         – newest → oldest (reverse-chronological)
+    #   * "chronological"   – oldest → newest
+    #   * "none" (default) – keep user-provided order untouched
+    sort_order: Literal["reverse", "chronological", "none"] = pydantic.Field(
+        default="none",
+        title="Sort Order",
+        description=(
+            "Determines how the entries inside each section are ordered before"
+            " rendering.\n\n"
+            "• \"reverse\" (default resume style): newest → oldest.\n"
+            "• \"chronological\": oldest → newest.\n"
+            "• \"none\": do not change the order supplied by the user."
         ),
     )
 

--- a/tests/test_sort_entries.py
+++ b/tests/test_sort_entries.py
@@ -1,0 +1,80 @@
+import pytest
+
+from rendercv.data import (
+    ExperienceEntry,
+    EducationEntry,
+    PublicationEntry,
+)
+from rendercv.data.models.computers import sort_entries
+
+
+@pytest.fixture
+def sample_entries():
+    """Return a heterogeneous list of entries with various date configurations."""
+    return [
+        # Ongoing role – should be considered the newest
+        ExperienceEntry(
+            company="Company A",
+            position="Engineer",
+            start_date="2023-01",
+            end_date="present",
+        ),
+        # Entry with only a single date
+        PublicationEntry(
+            title="Paper 1",
+            authors=["Doe"],
+            date="2022-06",
+        ),
+        # Entry with both start / end in the past
+        EducationEntry(
+            institution="Uni",
+            area="Area",
+            start_date="2010-09",
+            end_date="2014-06",
+        ),
+    ]
+
+
+@pytest.mark.parametrize("order, expected_first_cls", [
+    ("reverse", ExperienceEntry),
+    ("chronological", EducationEntry),
+    ("none", ExperienceEntry),  # original list keeps its order
+])
+def test_sort_entries_orders(sample_entries, order, expected_first_cls):
+    sorted_list = sort_entries(sample_entries, order)
+    assert isinstance(sorted_list[0], expected_first_cls)
+
+
+def test_sort_entries_preserves_original(sample_entries):
+    original_copy = list(sample_entries)
+    _ = sort_entries(sample_entries, "reverse")
+    # ensure original list not mutated
+    assert sample_entries == original_copy
+
+
+@pytest.mark.parametrize("invalid_order", ["ascending", "desc", "", None])
+def test_sort_entries_invalid_order(sample_entries, invalid_order):
+    with pytest.raises(ValueError):
+        sort_entries(sample_entries, invalid_order)  # type: ignore[arg-type]
+
+
+def test_sort_entries_missing_dates_raises():
+    entries = [
+        "Just a string",  # TextEntry without any date information
+    ]
+    with pytest.raises(ValueError):
+        sort_entries(entries, "reverse")
+
+
+# Malformed or non-ISO date strings should raise ValueError when sorting is requested.
+def test_sort_entries_malformed_date_raises():
+    entries = [
+        PublicationEntry(
+            title="Paper with funky date",
+            authors=["Doe"],
+            date="Fall 2023",  # not parseable by RenderCV
+        )
+    ]
+
+    with pytest.raises(ValueError):
+        sort_entries(entries, "reverse")


### PR DESCRIPTION
Add optional date sorting for résumé section entries with 'reverse', 'chronological', and 'none' order options.