### PR TITLE
Add entry sorting controls via settings

### DIFF
--- a/rendercv/data/models/curriculum_vitae.py
+++ b/rendercv/data/models/curriculum_vitae.py
@@ -439,6 +439,9 @@ class CurriculumVitae(RenderCVBaseModelWithExtraKeys):
         # `sections` key is preserved for RenderCV's internal use.
         alias="sections",
     )
+    sort_entries: Literal["reverse-chronological", "chronological", "none"] = (
+        "none"
+    )
 
     @pydantic.field_validator("photo")
     @classmethod
@@ -580,11 +583,14 @@ class CurriculumVitae(RenderCVBaseModelWithExtraKeys):
                     entry_types=entry_types.available_entry_models,
                 )
 
+                sort_order = self.sort_entries
+                sorted_entries = entry_types.sort_entries_by_date(entries, sort_order)
+
                 # SectionBase is used so that entries are not validated again:
                 section = SectionBase(
                     title=formatted_title,
                     entry_type=entry_type_name,
-                    entries=entries,
+                    entries=sorted_entries,
                 )
                 sections.append(section)
 

--- a/rendercv/data/models/rendercv_data_model.py
+++ b/rendercv/data/models/rendercv_data_model.py
@@ -75,5 +75,13 @@ class RenderCVDataModel(RenderCVBaseModelWithoutExtraKeys):
 
         return value
 
+    @pydantic.model_validator(mode="after")  # type: ignore
+    def apply_sort_entries(self) -> "RenderCVDataModel":
+        """Propagate sort order from settings to the CV."""
+
+        self.cv.sort_entries = self.rendercv_settings.sort_entries
+
+        return self
+
 
 rendercv_data_model_fields = tuple(RenderCVDataModel.model_fields.keys())

--- a/rendercv/data/models/rendercv_settings.py
+++ b/rendercv/data/models/rendercv_settings.py
@@ -5,12 +5,12 @@ The `rendercv.models.rendercv_settings` module contains the data model of the
 
 import datetime
 import pathlib
-from typing import Optional
+from typing import Literal
 
 import pydantic
 
+from . import computers
 from .base import RenderCVBaseModelWithoutExtraKeys
-from .computers import convert_string_to_path, replace_placeholders
 
 file_path_placeholder_description = (
     "The following placeholders can be used:\n- FULL_MONTH_NAME: Full name of the"
@@ -40,7 +40,7 @@ DATE_INPUT = datetime.date.today()
 class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
     """This class is the data model of the `render` command's settings."""
 
-    design: Optional[pathlib.Path] = pydantic.Field(
+    design: pathlib.Path | None = pydantic.Field(
         default=None,
         title="`design` Field's YAML File",
         description=(
@@ -48,7 +48,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    rendercv_settings: Optional[pathlib.Path] = pydantic.Field(
+    rendercv_settings: pathlib.Path | None = pydantic.Field(
         default=None,
         title="`rendercv_settings` Field's YAML File",
         description=(
@@ -57,7 +57,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    locale: Optional[pathlib.Path] = pydantic.Field(
+    locale: pathlib.Path | None = pydantic.Field(
         default=None,
         title="`locale` Field's YAML File",
         description=(
@@ -75,7 +75,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    pdf_path: Optional[pathlib.Path] = pydantic.Field(
+    pdf_path: pathlib.Path | None = pydantic.Field(
         default=None,
         title="PDF Path",
         description=(
@@ -84,7 +84,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    typst_path: Optional[pathlib.Path] = pydantic.Field(
+    typst_path: pathlib.Path | None = pydantic.Field(
         default=None,
         title="Typst Path",
         description=(
@@ -93,7 +93,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    html_path: Optional[pathlib.Path] = pydantic.Field(
+    html_path: pathlib.Path | None = pydantic.Field(
         default=None,
         title="HTML Path",
         description=(
@@ -102,7 +102,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    png_path: Optional[pathlib.Path] = pydantic.Field(
+    png_path: pathlib.Path | None = pydantic.Field(
         default=None,
         title="PNG Path",
         description=(
@@ -111,7 +111,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
-    markdown_path: Optional[pathlib.Path] = pydantic.Field(
+    markdown_path: pathlib.Path | None = pydantic.Field(
         default=None,
         title="Markdown Path",
         description=(
@@ -163,7 +163,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
     @classmethod
     def replace_placeholders(cls, value: str) -> str:
         """Replaces the placeholders in a string with the corresponding values."""
-        return replace_placeholders(value)
+        return computers.replace_placeholders(value)
 
     @pydantic.field_validator(
         "design",
@@ -177,7 +177,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         mode="before",
     )
     @classmethod
-    def convert_string_to_path(cls, value: Optional[str]) -> Optional[pathlib.Path]:
+    def convert_string_to_path(cls, value: str | None) -> pathlib.Path | None:
         """Converts a string to a `pathlib.Path` object by replacing the placeholders
         with the corresponding values. If the path is not an absolute path, it is
         converted to an absolute path by prepending the current working directory.
@@ -185,7 +185,7 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         if value is None:
             return None
 
-        return convert_string_to_path(value)
+        return computers.convert_string_to_path(value)
 
 
 class RenderCVSettings(RenderCVBaseModelWithoutExtraKeys):
@@ -205,7 +205,7 @@ class RenderCVSettings(RenderCVBaseModelWithoutExtraKeys):
             "default": None,
         },
     )
-    render_command: Optional[RenderCommandSettings] = pydantic.Field(
+    render_command: RenderCommandSettings | None = pydantic.Field(
         default=None,
         title="Render Command Settings",
         description=(
@@ -222,6 +222,17 @@ class RenderCVSettings(RenderCVBaseModelWithoutExtraKeys):
             " empty list."
         ),
     )
+    sort_entries: Literal["reverse-chronological", "chronological", "none"] = (
+        pydantic.Field(
+            default="none",
+            title="Sort Entries",
+            description=(
+                "How the entries should be sorted based on their dates."
+                " The available options are 'reverse-chronological', 'chronological', and 'none'."
+                " The default value is 'none'."
+            ),
+        )
+    )
 
     @pydantic.field_validator("date")
     @classmethod
@@ -233,3 +244,4 @@ class RenderCVSettings(RenderCVBaseModelWithoutExtraKeys):
         DATE_INPUT = value
 
         return value
+

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -998,3 +998,158 @@ def test_none_entries():
                 },
             )
         )
+
+
+def _create_sorting_data_model(order: str) -> data.RenderCVDataModel:
+    entries = [
+        {
+            "company": "A",
+            "position": "P",
+            "start_date": "2020-01-01",
+        },
+        {
+            "company": "B",
+            "position": "P",
+            "start_date": "2022-01-01",
+        },
+        {
+            "company": "C",
+            "position": "P",
+            "date": "2021-05-01",
+        },
+        {
+            "company": "D",
+            "position": "P",
+            "date": "2022-01-01",
+        },
+    ]
+
+    cv = data.CurriculumVitae(
+        name="John Doe",
+        sections={"exp": entries},
+    )
+
+    settings = data.RenderCVSettings(date="2024-01-01", sort_entries=order)
+
+    return data.RenderCVDataModel(cv=cv, rendercv_settings=settings)
+
+
+@pytest.mark.parametrize(
+    ("order", "expected"),
+    [
+        (
+            "reverse-chronological",
+            ["B", "A", "D", "C"],
+        ),
+        (
+            "chronological",
+            ["C", "D", "A", "B"],
+        ),
+        (
+            "none",
+            ["A", "B", "C", "D"],
+        ),
+    ],
+)
+def test_sort_entries(order, expected):
+    data_model = _create_sorting_data_model(order)
+    entries = data_model.cv.sections[0].entries
+    companies = [e.company for e in entries]
+    assert companies == expected
+
+
+def _create_sorting_data_model_with_ranges(order: str) -> data.RenderCVDataModel:
+    entries = [
+        {
+            "company": "A",
+            "position": "P",
+            "start_date": "2020-01-01",
+            "end_date": "2021-06-01",
+        },
+        {
+            "company": "B",
+            "position": "P",
+            "start_date": "2019-01-01",
+            "end_date": "2022-06-01",
+        },
+        {
+            "company": "C",
+            "position": "P",
+            "start_date": "2021-01-01",
+            "end_date": "2022-06-01",
+        },
+        {
+            "company": "D",
+            "position": "P",
+            "date": "2020-05-01",
+        },
+    ]
+
+    cv = data.CurriculumVitae(
+        name="John Doe",
+        sections={"exp": entries},
+    )
+
+    settings = data.RenderCVSettings(date="2024-01-01", sort_entries=order)
+
+    return data.RenderCVDataModel(cv=cv, rendercv_settings=settings)
+
+
+@pytest.mark.parametrize(
+    ("order", "expected"),
+    [
+        (
+            "reverse-chronological",
+            ["C", "B", "A", "D"],
+        ),
+        (
+            "chronological",
+            ["D", "A", "B", "C"],
+        ),
+    ],
+)
+def test_sort_entries_with_ranges(order, expected):
+    data_model = _create_sorting_data_model_with_ranges(order)
+    entries = data_model.cv.sections[0].entries
+    companies = [e.company for e in entries]
+    assert companies == expected
+
+
+def _create_sorting_data_model_with_ties(order: str) -> data.RenderCVDataModel:
+    entries = [
+        {
+            "company": "A",
+            "position": "P",
+            "date": "2020-01-01",
+        },
+        {
+            "company": "B",
+            "position": "P",
+            "date": "2020-01-01",
+        },
+        {
+            "company": "C",
+            "position": "P",
+            "date": "2020-01-02",
+        },
+    ]
+
+    cv = data.CurriculumVitae(
+        name="John Doe",
+        sections={"exp": entries},
+    )
+
+    settings = data.RenderCVSettings(date="2024-01-01", sort_entries=order)
+
+    return data.RenderCVDataModel(cv=cv, rendercv_settings=settings)
+
+
+@pytest.mark.parametrize("order", ["reverse-chronological", "chronological"])
+def test_sort_entries_tie_keeps_order(order):
+    data_model = _create_sorting_data_model_with_ties(order)
+    entries = data_model.cv.sections[0].entries
+    companies = [e.company for e in entries]
+    if order == "reverse-chronological":
+        assert companies == ["C", "A", "B"]
+    else:
+        assert companies == ["A", "B", "C"]


### PR DESCRIPTION
## Summary
- enable sorting entries by date and allow configuration through RenderCVSettings
- compute end and start dates for sorting and stable ordering
- default to original YAML order when dates tie
- add comprehensive tests for sorting including tie cases

## Testing
- `pre-commit run --files rendercv/data/models/entry_types.py tests/test_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e99e076748326baf9d75f947c17b3